### PR TITLE
Fix header length handling (again)

### DIFF
--- a/src/header.rs
+++ b/src/header.rs
@@ -246,6 +246,11 @@ impl Header {
         self.v3.autoclear.set(try!(io.read_u64()));
         self.v3.refcount_order = try!(io.read_u32());
         self.v3.header_length = try!(io.read_u32());
+        if self.v3.header_length as u64 > io.position() {
+            // There are addition fields.
+            // XXX compression header field ought to be extracted
+            io.set_position(self.v3.header_length as u64);
+        }
         let actual_length = io.position();
         try!(self.read_extensions(io));
         if self.c.backing_file_offset != 0 {
@@ -270,13 +275,8 @@ impl Header {
         }
         if self.v3.header_length as u64 != actual_length {
             return Err(Error::FileFormat(format!("header is {} bytes, file claims {}",
-                                                 io.position(),
+                                                 actual_length,
                                                  self.v3.header_length)));
-        }
-        if actual_length != HEADER_LENGTH_V3 as u64 {
-            return Err(Error::Internal(format!("header must be {} bytes, but we read {}",
-                                               HEADER_LENGTH_V3,
-                                               io.position())));
         }
         if io.position() > self.cluster_size() {
             return Err(Error::FileFormat("complete header too big for first cluster".to_owned()));

--- a/src/header.rs
+++ b/src/header.rs
@@ -268,7 +268,7 @@ impl Header {
         if self.v3.refcount_order > 6 {
             return Err(Error::FileFormat(format!("bad refcount_order {}", self.v3.refcount_order)));
         }
-        if self.v3.header_length as u64 != io.position() {
+        if self.v3.header_length as u64 != actual_length {
             return Err(Error::FileFormat(format!("header is {} bytes, file claims {}",
                                                  io.position(),
                                                  self.v3.header_length)));


### PR DESCRIPTION
Revert the last change to the header length check.  Properly skip any additional fields, and make the correct check, also remove an entirely bogus check.This is tested, with both the test image in the tests/ directory, as well as newly created images by qemu-img (6.2) on both MacOS and OpenBSD, according to this [issue](https://github.com/vasi/qcow2-fuse/issues/4)